### PR TITLE
Standardize local Dev builds and screenshot previews

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -23,6 +23,15 @@ Das Projekt enthält weder Analytics, Werbung, Tracking, Konto noch Cloud-Upload
 
 ## Lokale Builds und Gatekeeper
 
+Den lokalen Dev-Build erstellst du mit:
+
+```bash
+bash Scripts/build-development.sh
+```
+
+Die einzige startbare Dev-App liegt anschließend unter `dist/local-test/HealthAtlas-Development/HealthAtlas Dev.app`.
+Der Ordner `.build` ist ausschließlich der temporäre Compiler-Arbeitsbereich von Xcode, keine zweite App zum Öffnen.
+
 Die aktuellen Dev- und Beta-Builds sind ad hoc signiert, weil für das Projekt
 kein Apple-Developer-Account vorhanden ist. macOS Gatekeeper zeigt beim ersten
 Öffnen daher einen Hinweis an.
@@ -66,27 +75,27 @@ Alle folgenden Screenshots verwenden ausschließlich die mitgelieferten syntheti
 
 ### Import
 
-![Leere HealthAtlas-Startansicht für den Apple-Health-Import](Screenshots/import.png)
+<a href="Screenshots/import.png"><img src="Screenshots/import.png" alt="Leere HealthAtlas-Startansicht für den Apple-Health-Import" width="50%"></a>
 
 ### Übersicht
 
-![HealthAtlas-Übersicht mit ausgewählten Gesundheits-Kacheln](Screenshots/overview.png)
+<a href="Screenshots/overview.png"><img src="Screenshots/overview.png" alt="HealthAtlas-Übersicht mit ausgewählten Gesundheits-Kacheln" width="50%"></a>
 
 ### Quellen
 
-![HealthAtlas-Auswahl importierter Apple-Health-Datentypen](Screenshots/sources.png)
+<a href="Screenshots/sources.png"><img src="Screenshots/sources.png" alt="HealthAtlas-Auswahl importierter Apple-Health-Datentypen" width="50%"></a>
 
 ### Verläufe
 
-![Interaktiver Herzfrequenz-Verlauf in HealthAtlas](Screenshots/trends.png)
+<a href="Screenshots/trends.png"><img src="Screenshots/trends.png" alt="Interaktiver Herzfrequenz-Verlauf in HealthAtlas" width="50%"></a>
 
 ### Einblicke
 
-![Lokaler Herzfrequenz-Einblick in HealthAtlas](Screenshots/insights.png)
+<a href="Screenshots/insights.png"><img src="Screenshots/insights.png" alt="Lokaler Herzfrequenz-Einblick in HealthAtlas" width="50%"></a>
 
 ### Design-Studio
 
-![HealthAtlas-Theme- und Spracheinstellungen](Screenshots/design-studio.png)
+<a href="Screenshots/design-studio.png"><img src="Screenshots/design-studio.png" alt="HealthAtlas-Theme- und Spracheinstellungen" width="50%"></a>
 
 ## Beta-Pakete
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ The project contains no analytics, advertising, tracking, account or cloud uploa
 
 ## Local builds and Gatekeeper
 
+Create the local Dev app with:
+
+```bash
+bash Scripts/build-development.sh
+```
+
+The only runnable Dev output is `dist/local-test/HealthAtlas-Development/HealthAtlas Dev.app`.
+The `.build` directory is only Xcode's temporary compiler workspace, not a second app to open.
+
 The current Dev and Beta builds are ad-hoc signed because the project has no
 Apple Developer account. macOS Gatekeeper will therefore show a warning the
 first time one is opened.
@@ -64,27 +73,27 @@ All screenshots below use the included synthetic demo data — no personal healt
 
 ### Import
 
-![HealthAtlas empty import screen](Screenshots/import.png)
+<a href="Screenshots/import.png"><img src="Screenshots/import.png" alt="HealthAtlas empty import screen" width="50%"></a>
 
 ### Overview
 
-![HealthAtlas overview with selected health cards](Screenshots/overview.png)
+<a href="Screenshots/overview.png"><img src="Screenshots/overview.png" alt="HealthAtlas overview with selected health cards" width="50%"></a>
 
 ### Sources
 
-![HealthAtlas source selection for imported Apple Health data types](Screenshots/sources.png)
+<a href="Screenshots/sources.png"><img src="Screenshots/sources.png" alt="HealthAtlas source selection for imported Apple Health data types" width="50%"></a>
 
 ### Trends
 
-![HealthAtlas interactive heart-rate trend](Screenshots/trends.png)
+<a href="Screenshots/trends.png"><img src="Screenshots/trends.png" alt="HealthAtlas interactive heart-rate trend" width="50%"></a>
 
 ### Insights
 
-![HealthAtlas local heart-rate insight](Screenshots/insights.png)
+<a href="Screenshots/insights.png"><img src="Screenshots/insights.png" alt="HealthAtlas local heart-rate insight" width="50%"></a>
 
 ### Design Studio
 
-![HealthAtlas theme and language settings](Screenshots/design-studio.png)
+<a href="Screenshots/design-studio.png"><img src="Screenshots/design-studio.png" alt="HealthAtlas theme and language settings" width="50%"></a>
 
 ## Beta packages
 

--- a/Scripts/build-channel.sh
+++ b/Scripts/build-channel.sh
@@ -24,3 +24,17 @@ HEALTHATLAS_SKIP_SCHEME_CLEAN=YES xcodebuild \
   -configuration "$configuration" \
   -derivedDataPath "$derived_data" \
   build
+
+# The compiler cache stays private under .build; every usable Dev app is written
+# to the same stable local-test location as AppAtlas.
+if [[ "$channel" == "dev" ]]; then
+  app_source="$derived_data/Build/Products/$configuration/HealthAtlas.app"
+  output_directory="$root/dist/local-test/HealthAtlas-Development"
+  app_bundle="$output_directory/HealthAtlas Dev.app"
+  rm -rf "$output_directory"
+  mkdir -p "$output_directory"
+  ditto "$app_source" "$app_bundle"
+  codesign --force --deep --sign - "$app_bundle"
+  codesign --verify --deep --strict "$app_bundle"
+  echo "Lokaler Dev-Build: $app_bundle"
+fi

--- a/Scripts/build-development.sh
+++ b/Scripts/build-development.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+
+# The only supported local-development entry point. Its runnable app is always
+# written to dist/local-test/HealthAtlas-Development, never to DerivedData.
+bash "$root/Scripts/prepare-build-layout.sh"
+bash "$root/Scripts/build-channel.sh" dev


### PR DESCRIPTION
Makes README screenshots 50% clickable previews, documents the synthetic demo images, and creates one stable local Dev app under dist/local-test.